### PR TITLE
Add demo open data catalog.

### DIFF
--- a/{{ cookiecutter.repo_name }}/catalogs/catalog.yml
+++ b/{{ cookiecutter.repo_name }}/catalogs/catalog.yml
@@ -1,0 +1,19 @@
+metadata:
+  version: 1
+sources:
+  la_open_data:
+    driver: dcat
+    args:
+      url: https://data.lacity.org/data.json
+  la_geohub:
+    driver: dcat
+    args:
+      url: http://geohub.lacity.org/data.json
+  la_county_open_data:
+    driver: dcat
+    args:
+      url: https://data.lacounty.gov/data.json
+  scag_gis_portal:
+    driver: dcat
+    args:
+      url: http://gisdata-scag.opendata.arcgis.com/data.json


### PR DESCRIPTION
Fixes #1, adding catalogs for LA open data, LA GeoHub, LA County open data, and SCAG GIS data portal.